### PR TITLE
Add discipline task tracker

### DIFF
--- a/discipline_gui.py
+++ b/discipline_gui.py
@@ -1,0 +1,75 @@
+import json
+from pathlib import Path
+import tkinter as tk
+from tkinter import messagebox
+
+TASKS_FILE = Path("tasks.json")
+
+def load_tasks():
+    if TASKS_FILE.exists():
+        with TASKS_FILE.open("r", encoding="utf-8") as f:
+            return json.load(f)
+    return []
+
+
+def save_tasks(tasks):
+    with TASKS_FILE.open("w", encoding="utf-8") as f:
+        json.dump(tasks, f, ensure_ascii=False, indent=2)
+
+
+def refresh_listbox(listbox):
+    listbox.delete(0, tk.END)
+    for task in load_tasks():
+        status = "✔" if task.get("done") else "✗"
+        listbox.insert(tk.END, f"{task['id']}: [{status}] {task['desc']}")
+
+
+def add_task(entry, listbox):
+    desc = entry.get().strip()
+    if not desc:
+        return
+    tasks = load_tasks()
+    task_id = max([t["id"] for t in tasks], default=0) + 1
+    tasks.append({"id": task_id, "desc": desc, "done": False})
+    save_tasks(tasks)
+    entry.delete(0, tk.END)
+    refresh_listbox(listbox)
+
+
+def delete_task(listbox):
+    selection = listbox.curselection()
+    if not selection:
+        messagebox.showinfo("Remove task", "Select a task to remove.")
+        return
+    index = selection[0]
+    tasks = load_tasks()
+    tasks.pop(index)
+    save_tasks(tasks)
+    refresh_listbox(listbox)
+
+
+def main():
+    root = tk.Tk()
+    root.title("Discipline Tasks")
+
+    listbox = tk.Listbox(root, width=50)
+    listbox.pack(padx=10, pady=10)
+
+    entry = tk.Entry(root, width=50)
+    entry.pack(padx=10)
+
+    btn_frame = tk.Frame(root)
+    btn_frame.pack(padx=10, pady=5)
+
+    add_btn = tk.Button(btn_frame, text="Add", command=lambda: add_task(entry, listbox))
+    add_btn.pack(side=tk.LEFT, padx=5)
+
+    del_btn = tk.Button(btn_frame, text="Remove", command=lambda: delete_task(listbox))
+    del_btn.pack(side=tk.LEFT, padx=5)
+
+    refresh_listbox(listbox)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/discipline_program.py
+++ b/discipline_program.py
@@ -1,0 +1,68 @@
+import json
+import argparse
+from pathlib import Path
+
+TASKS_FILE = Path("tasks.json")
+
+def load_tasks():
+    if TASKS_FILE.exists():
+        with TASKS_FILE.open("r", encoding="utf-8") as f:
+            return json.load(f)
+    return []
+
+def save_tasks(tasks):
+    with TASKS_FILE.open("w", encoding="utf-8") as f:
+        json.dump(tasks, f, ensure_ascii=False, indent=2)
+
+def add_task(description):
+    tasks = load_tasks()
+    task_id = max([t["id"] for t in tasks], default=0) + 1
+    tasks.append({"id": task_id, "desc": description, "done": False})
+    save_tasks(tasks)
+    print(f"Task #{task_id} added: {description}")
+
+def list_tasks():
+    tasks = load_tasks()
+    if not tasks:
+        print("No tasks found.")
+        return
+    for t in tasks:
+        status = "✔" if t["done"] else "✗"
+        print(f"{t['id']}: [{status}] {t['desc']}")
+
+def complete_task(task_id):
+    tasks = load_tasks()
+    for t in tasks:
+        if t["id"] == task_id:
+            t["done"] = True
+            save_tasks(tasks)
+            print(f"Task #{task_id} marked as complete.")
+            return
+    print(f"Task #{task_id} not found.")
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Simple discipline task tracker")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    add_p = subparsers.add_parser("add", help="Add a new task")
+    add_p.add_argument("description", help="Task description")
+
+    list_p = subparsers.add_parser("list", help="List all tasks")
+
+    done_p = subparsers.add_parser("done", help="Mark a task as complete")
+    done_p.add_argument("id", type=int, help="Task ID")
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    if args.command == "add":
+        add_task(args.description)
+    elif args.command == "list":
+        list_tasks()
+    elif args.command == "done":
+        complete_task(args.id)
+
+if __name__ == "__main__":
+    main()

--- a/readme.md
+++ b/readme.md
@@ -16,3 +16,13 @@ python discipline_program.py done 1
 ```
 
 Tasks are stored in `tasks.json` in the repository directory.
+
+## GUI
+
+You can manage tasks with a simple graphical interface:
+
+```bash
+python discipline_gui.py
+```
+
+The window lists existing tasks and lets you add or remove them.

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,18 @@
-Hello codex
+# Discipline Program
+
+This repository contains a simple command-line program for tracking tasks and building self-discipline.
+
+## Usage
+
+```bash
+# Add a new task
+python discipline_program.py add "Read 10 pages of a book"
+
+# List current tasks
+python discipline_program.py list
+
+# Mark a task as complete
+python discipline_program.py done 1
+```
+
+Tasks are stored in `tasks.json` in the repository directory.


### PR DESCRIPTION
## Summary
- add a CLI program `discipline_program.py` to manage daily tasks for self-discipline
- update README with usage instructions

## Testing
- `python3 -m py_compile discipline_program.py`

------
https://chatgpt.com/codex/tasks/task_e_68400905ba10832fb624ff3357630cee