### PR TITLE
Add 24h timeline web app with draggable task blocks, form and styles

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,212 @@
+const isBrowser = typeof window !== 'undefined' && typeof document !== 'undefined';
+
+if (!isBrowser) {
+  console.log('Ta aplikacja działa w przeglądarce. Otwórz plik index.html.');
+}
+
+const DAY_MINUTES = 24 * 60;
+const UNIT_MINUTES = 15;
+const PIXELS_PER_HOUR = 40;
+const PIXELS_PER_MINUTE = PIXELS_PER_HOUR / 60;
+const LANE_GAP = 8;
+
+const palette = ['#66d9ff', '#8ce99a', '#ffd166', '#c19bff', '#ff9f9f', '#5ff2b7'];
+
+const tasks = [
+  { id: crypto.randomUUID(), name: 'Poranna rutyna', start: '07:00', duration: 45 },
+  { id: crypto.randomUUID(), name: 'Praca głęboka', start: '09:00', duration: 180 },
+  { id: crypto.randomUUID(), name: 'Spacer', start: '13:00', duration: 30 },
+  { id: crypto.randomUUID(), name: 'Maile i administracja', start: '14:00', duration: 60 }
+];
+
+function minutesFromTime(value) {
+  const [h, m] = value.split(':').map(Number);
+  return h * 60 + m;
+}
+
+function timeFromMinutes(value) {
+  const clamped = Math.max(0, Math.min(DAY_MINUTES - UNIT_MINUTES, value));
+  const hours = Math.floor(clamped / 60)
+    .toString()
+    .padStart(2, '0');
+  const minutes = (clamped % 60).toString().padStart(2, '0');
+  return `${hours}:${minutes}`;
+}
+
+function formatDuration(min) {
+  const h = Math.floor(min / 60);
+  const m = min % 60;
+  if (h && m) return `${h}h ${m}m`;
+  if (h) return `${h}h`;
+  return `${m}m`;
+}
+
+function buildScheduleMeta() {
+  const usedMinutes = tasks.reduce((sum, task) => sum + task.duration, 0);
+  const freeMinutes = Math.max(DAY_MINUTES - usedMinutes, 0);
+  return { usedMinutes, freeMinutes };
+}
+
+function doTasksOverlap(a, b) {
+  const aStart = minutesFromTime(a.start);
+  const aEnd = aStart + a.duration;
+  const bStart = minutesFromTime(b.start);
+  const bEnd = bStart + b.duration;
+  return aStart < bEnd && bStart < aEnd;
+}
+
+function computeLanes(sortedTasks) {
+  const lanes = [];
+
+  sortedTasks.forEach((task) => {
+    let laneIndex = 0;
+    while (true) {
+      if (!lanes[laneIndex]) {
+        lanes[laneIndex] = [task];
+        task.lane = laneIndex;
+        break;
+      }
+
+      const hasOverlap = lanes[laneIndex].some((existing) => doTasksOverlap(existing, task));
+      if (!hasOverlap) {
+        lanes[laneIndex].push(task);
+        task.lane = laneIndex;
+        break;
+      }
+      laneIndex += 1;
+    }
+  });
+
+  return lanes.length;
+}
+
+function renderHours(hoursCol) {
+  hoursCol.innerHTML = '';
+  for (let h = 0; h <= 24; h += 1) {
+    const marker = document.createElement('div');
+    marker.className = 'hour-label';
+    marker.style.top = `${h * PIXELS_PER_HOUR}px`;
+    marker.textContent = `${h.toString().padStart(2, '0')}:00`;
+    hoursCol.appendChild(marker);
+  }
+}
+
+function render() {
+  if (!isBrowser) return;
+
+  const summary = document.getElementById('summary');
+  const timeline = document.getElementById('timeline');
+  const taskList = document.getElementById('task-list');
+  const hoursCol = document.getElementById('hours');
+
+  if (!summary || !timeline || !taskList || !hoursCol) return;
+
+  const { usedMinutes, freeMinutes } = buildScheduleMeta();
+  summary.textContent = `Zaplanowano ${formatDuration(usedMinutes)} z 24h. Wolne: ${formatDuration(
+    freeMinutes
+  )}.`;
+
+  renderHours(hoursCol);
+  timeline.innerHTML = '';
+  taskList.innerHTML = '';
+
+  const sortedTasks = [...tasks].sort((a, b) => minutesFromTime(a.start) - minutesFromTime(b.start));
+  const lanesCount = Math.max(1, computeLanes(sortedTasks));
+  const laneWidth = (timeline.clientWidth - 20 - (lanesCount - 1) * LANE_GAP) / lanesCount;
+
+  sortedTasks.forEach((task, idx) => {
+    const block = document.createElement('div');
+    block.className = 'task-block';
+    block.dataset.taskId = task.id;
+
+    const top = minutesFromTime(task.start) * PIXELS_PER_MINUTE;
+    const height = task.duration * PIXELS_PER_MINUTE;
+    const left = 10 + task.lane * (laneWidth + LANE_GAP);
+
+    block.style.top = `${top}px`;
+    block.style.height = `${Math.max(height, 24)}px`;
+    block.style.left = `${left}px`;
+    block.style.width = `${laneWidth}px`;
+    block.style.background = `linear-gradient(135deg, ${palette[idx % palette.length]}, #ffffff)`;
+    block.innerHTML = `<strong>${task.name}</strong><span>${task.start} • ${formatDuration(task.duration)}</span>`;
+
+    enableDrag(block, timeline);
+    timeline.appendChild(block);
+
+    const li = document.createElement('li');
+    li.textContent = `${task.start} • ${task.name} • ${formatDuration(task.duration)}`;
+    taskList.appendChild(li);
+  });
+}
+
+function enableDrag(block, timeline) {
+  let dragOffsetY = 0;
+
+  const onPointerMove = (event) => {
+    const task = tasks.find((t) => t.id === block.dataset.taskId);
+    if (!task) return;
+
+    const timelineRect = timeline.getBoundingClientRect();
+    const minTop = 0;
+    const maxTop = DAY_MINUTES * PIXELS_PER_MINUTE - task.duration * PIXELS_PER_MINUTE;
+    const rawTop = event.clientY - timelineRect.top - dragOffsetY;
+    const clampedTop = Math.max(minTop, Math.min(maxTop, rawTop));
+
+    const rawMinutes = clampedTop / PIXELS_PER_MINUTE;
+    const snapped = Math.round(rawMinutes / UNIT_MINUTES) * UNIT_MINUTES;
+
+    task.start = timeFromMinutes(snapped);
+    render();
+  };
+
+  const onPointerUp = () => {
+    block.classList.remove('dragging');
+    document.removeEventListener('pointermove', onPointerMove);
+    document.removeEventListener('pointerup', onPointerUp);
+  };
+
+  block.addEventListener('pointerdown', (event) => {
+    event.preventDefault();
+    block.classList.add('dragging');
+    dragOffsetY = event.offsetY;
+
+    document.addEventListener('pointermove', onPointerMove);
+    document.addEventListener('pointerup', onPointerUp);
+  });
+}
+
+function setupForm() {
+  if (!isBrowser) return;
+
+  const taskForm = document.getElementById('task-form');
+  if (!taskForm) return;
+
+  taskForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+
+    const formData = new FormData(taskForm);
+    const name = formData.get('name').toString().trim();
+    const start = formData.get('start').toString();
+    const duration = Number(formData.get('duration'));
+
+    if (!name || !start || !duration || duration < UNIT_MINUTES) return;
+
+    const startMinutes = minutesFromTime(start);
+    if (startMinutes + duration > DAY_MINUTES) {
+      alert('To zadanie wychodzi poza zakres doby 24h.');
+      return;
+    }
+
+    tasks.push({ id: crypto.randomUUID(), name, start, duration });
+    taskForm.reset();
+    document.getElementById('duration').value = 60;
+    render();
+  });
+}
+
+if (isBrowser) {
+  window.addEventListener('resize', render);
+}
+
+setupForm();
+render();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html lang="pl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Kwadratowy Plan Dnia</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="app">
+      <header>
+        <h1>Kwadratowy Plan Dnia (24h)</h1>
+        <p>
+          Wizualizacja czasu dla osób z ADHD: im dłuższe zadanie, tym większy
+          kwadrat.
+        </p>
+      </header>
+
+      <section class="panel">
+        <h2>Dodaj zadanie</h2>
+        <form id="task-form" class="task-form">
+          <label>
+            Nazwa
+            <input id="name" name="name" required placeholder="np. Praca głęboka" />
+          </label>
+          <label>
+            Start
+            <input id="start" name="start" type="time" required />
+          </label>
+          <label>
+            Czas (min)
+            <input
+              id="duration"
+              name="duration"
+              type="number"
+              min="15"
+              step="15"
+              value="60"
+              required
+            />
+          </label>
+          <button type="submit">Dodaj blok</button>
+        </form>
+      </section>
+
+      <section class="panel overview">
+        <h2>Podsumowanie 24h</h2>
+        <p id="summary"></p>
+        <div class="legend">
+          <span><i class="used"></i> Zaplanowane</span>
+          <span><i class="free"></i> Wolny czas</span>
+        </div>
+      </section>
+
+      <section class="panel">
+        <h2>Oś czasu (24h)</h2>
+        <p class="hint">
+          Przeciągnij blok w górę/dół, aby zmienić godzinę startu (snap co 15 min).
+        </p>
+        <div class="timeline-wrap">
+          <div id="hours" class="hours" aria-hidden="true"></div>
+          <div id="timeline" class="timeline" aria-live="polite"></div>
+        </div>
+      </section>
+
+      <section class="panel">
+        <h2>Lista zadań</h2>
+        <ul id="task-list" class="task-list"></ul>
+      </section>
+    </main>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,18 @@
-Hello codex
+# Kwadratowy Plan Dnia
+
+Prosty prototyp aplikacji webowej do wizualizacji zadań w skali 24h.
+
+## Idea
+- Zadania są pokazane jako bloki na **osi czasu 24h**.
+- Bloki można **przeciągać** w górę/dół, aby zmieniać godzinę startu.
+- Pozycja bloku snapuje co 15 minut, żeby plan był czytelny i spójny.
+- Podsumowanie pokazuje łączny czas zaplanowany i wolny bufor.
+
+## Uruchomienie
+Otwórz plik `index.html` w przeglądarce.
+
+## Dla kogo
+Aplikacja celuje w osoby z ADHD, które potrzebują szybkiej, graficznej oceny:
+- ile dnia już jest zajęte,
+- które zadania są „duże” czasowo,
+- ile zostało buforu.

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,175 @@
+:root {
+  --bg: #0f1220;
+  --panel: #1b2140;
+  --text: #f4f6ff;
+  --muted: #b8bfd9;
+  --accent: #6ce5e8;
+  --free: #4c5c96;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  background: radial-gradient(circle at top, #1d2450, var(--bg));
+  color: var(--text);
+}
+
+.app {
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 24px;
+  display: grid;
+  gap: 16px;
+}
+
+.panel {
+  background: rgba(27, 33, 64, 0.85);
+  border: 1px solid #38457e;
+  border-radius: 14px;
+  padding: 16px;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+.task-form {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+label {
+  display: grid;
+  gap: 6px;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+input,
+button {
+  border-radius: 10px;
+  border: 1px solid #465695;
+  padding: 10px;
+  font-size: 1rem;
+}
+
+button {
+  background: var(--accent);
+  color: #04131b;
+  font-weight: 700;
+  cursor: pointer;
+  align-self: end;
+}
+
+button:hover {
+  filter: brightness(1.05);
+}
+
+.legend {
+  display: flex;
+  gap: 16px;
+  color: var(--muted);
+}
+
+.legend i {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  margin-right: 6px;
+  border-radius: 4px;
+}
+
+.used {
+  background: linear-gradient(135deg, #66d9ff, #5ff2b7);
+}
+
+.free {
+  background: var(--free);
+}
+
+.timeline-wrap {
+  display: grid;
+  grid-template-columns: 62px 1fr;
+  gap: 10px;
+}
+
+.hours {
+  position: relative;
+  height: 960px;
+}
+
+.hour-label {
+  position: absolute;
+  left: 0;
+  transform: translateY(-50%);
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
+.timeline {
+  position: relative;
+  height: 960px;
+  border-radius: 12px;
+  border: 1px solid #465695;
+  background:
+    repeating-linear-gradient(
+      to bottom,
+      rgba(255, 255, 255, 0.07) 0,
+      rgba(255, 255, 255, 0.07) 1px,
+      transparent 1px,
+      transparent 10px
+    ),
+    #1b244c;
+}
+
+.task-block {
+  position: absolute;
+  left: 10px;
+  right: 10px;
+  border-radius: 10px;
+  padding: 8px;
+  font-size: 0.8rem;
+  overflow: hidden;
+  color: #072028;
+  font-weight: 600;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  cursor: grab;
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.22);
+}
+
+.task-block:active {
+  cursor: grabbing;
+}
+
+.task-block.dragging {
+  opacity: 0.85;
+  outline: 2px dashed #fff;
+}
+
+.hint {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.task-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.task-list li {
+  background: #243060;
+  border-radius: 8px;
+  padding: 10px;
+}


### PR DESCRIPTION
### Motivation
- Provide a simple web prototype to visualize a 24h schedule where task duration is represented as block size to help quick perception of time usage. 
- Enable fast repositioning of tasks by dragging with 15-minute snapping to keep the plan legible and consistent.
- Show overall used vs free time for the day to support quick planning decisions.

### Description
- Add `index.html` as the app shell with a task form, timeline, hours column, summary and task list. 
- Implement core logic in `app.js` including `minutesFromTime`, `timeFromMinutes`, `computeLanes`, `render`, and `enableDrag` to render tasks, compute non-overlapping lanes, and support pointer-drag with 15-minute snap and 24h bounds. 
- Style the UI in `styles.css` with a responsive panel layout, timeline grid, draggable task blocks, and visual legend. 
- Add `readme.md` with project purpose, usage and target audience information.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e774c5520c832f93e5a91967b6587b)