### PR TITLE
Create handmade workshop landing page with signup bot and admin panel

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,168 @@
+const defaultSlots = [
+  { id: "2026-06-12 17:00", title: "12.06.2026, 17:00 • Makrama", capacity: 5 },
+  { id: "2026-06-19 18:00", title: "19.06.2026, 18:00 • Biżuteria handmade", capacity: 6 },
+  { id: "2026-06-26 17:30", title: "26.06.2026, 17:30 • Świece sojowe", capacity: 4 }
+];
+
+const state = {
+  slots: JSON.parse(localStorage.getItem("handmade_slots") || "null") || defaultSlots,
+  signups: JSON.parse(localStorage.getItem("handmade_signups") || "[]")
+};
+
+const slotsList = document.getElementById("slotsList");
+const slotSelect = document.getElementById("slotSelect");
+const signupForm = document.getElementById("signupForm");
+const signupMessage = document.getElementById("signupMessage");
+const adminRows = document.getElementById("adminRows");
+const clearDataButton = document.getElementById("clearData");
+
+const chatWindow = document.getElementById("chatWindow");
+const chatForm = document.getElementById("chatForm");
+const chatInput = document.getElementById("chatInput");
+
+function save() {
+  localStorage.setItem("handmade_slots", JSON.stringify(state.slots));
+  localStorage.setItem("handmade_signups", JSON.stringify(state.signups));
+}
+
+function freePlaces(slotId) {
+  const slot = state.slots.find(s => s.id === slotId);
+  const taken = state.signups.filter(s => s.slotId === slotId).length;
+  return Math.max(slot.capacity - taken, 0);
+}
+
+function renderSlots() {
+  slotsList.innerHTML = "";
+  slotSelect.innerHTML = "";
+
+  state.slots.forEach(slot => {
+    const free = freePlaces(slot.id);
+
+    const li = document.createElement("li");
+    li.textContent = `${slot.title} — wolne miejsca: ${free}`;
+    slotsList.appendChild(li);
+
+    const option = document.createElement("option");
+    option.value = slot.id;
+    option.disabled = free === 0;
+    option.textContent = free === 0 ? `${slot.title} (brak miejsc)` : `${slot.title} (${free} wolnych)`;
+    slotSelect.appendChild(option);
+  });
+}
+
+function renderAdmin() {
+  adminRows.innerHTML = "";
+  state.signups.forEach(entry => {
+    const tr = document.createElement("tr");
+    tr.innerHTML = `
+      <td>${entry.name}</td>
+      <td>${entry.email}<br>${entry.phone}</td>
+      <td>${entry.slotTitle}</td>
+      <td>${entry.source}</td>
+    `;
+    adminRows.appendChild(tr);
+  });
+}
+
+function addSignup(data) {
+  const free = freePlaces(data.slotId);
+  if (free <= 0) return { ok: false, message: "Brak miejsc w tym terminie." };
+
+  state.signups.push(data);
+  save();
+  renderSlots();
+  renderAdmin();
+  return { ok: true, message: `Super! ${data.name}, jesteś zapisana/y na: ${data.slotTitle}` };
+}
+
+signupForm.addEventListener("submit", e => {
+  e.preventDefault();
+  const fd = new FormData(signupForm);
+  const slotId = fd.get("slot");
+  const slot = state.slots.find(s => s.id === slotId);
+
+  const result = addSignup({
+    name: fd.get("name"),
+    email: fd.get("email"),
+    phone: fd.get("phone"),
+    slotId,
+    slotTitle: slot.title,
+    source: "Formularz"
+  });
+
+  signupMessage.textContent = result.message;
+  if (result.ok) signupForm.reset();
+});
+
+function botSpeak(text) {
+  const p = document.createElement("p");
+  p.className = "msg bot";
+  p.textContent = `Bot: ${text}`;
+  chatWindow.appendChild(p);
+  chatWindow.scrollTop = chatWindow.scrollHeight;
+}
+
+function userSpeak(text) {
+  const p = document.createElement("p");
+  p.className = "msg user";
+  p.textContent = `Ty: ${text}`;
+  chatWindow.appendChild(p);
+}
+
+function botHandle(input) {
+  const text = input.toLowerCase();
+
+  if (text.includes("wolne") || text.includes("termin")) {
+    const summary = state.slots
+      .map(s => `${s.title} (${freePlaces(s.id)} wolnych)`)
+      .join("; ");
+    return `Aktualne miejsca: ${summary}`;
+  }
+
+  if (text.includes("zapis") || text.includes("chcę")) {
+    const candidate = state.slots.find(s => text.includes(s.id.slice(5, 10).replace("-", ".")) || text.includes(s.title.slice(0, 5)));
+    const slot = candidate || state.slots.find(s => freePlaces(s.id) > 0);
+
+    if (!slot) return "Niestety wszystkie terminy są pełne.";
+
+    const fakeName = "Uczestnik z czatu";
+    const result = addSignup({
+      name: fakeName,
+      email: "chat@lokalnie.pl",
+      phone: "000-000-000",
+      slotId: slot.id,
+      slotTitle: slot.title,
+      source: "Bot"
+    });
+
+    return result.ok
+      ? `Zapisałem Cię wstępnie na ${slot.title}. Organizator skontaktuje się, by potwierdzić dane.`
+      : result.message;
+  }
+
+  return "Mogę: 1) pokazać wolne terminy, 2) zrobić szybki zapis na najbliższe szkolenie.";
+}
+
+chatForm.addEventListener("submit", e => {
+  e.preventDefault();
+  const value = chatInput.value.trim();
+  if (!value) return;
+
+  userSpeak(value);
+  const answer = botHandle(value);
+  botSpeak(answer);
+  chatInput.value = "";
+});
+
+clearDataButton.addEventListener("click", () => {
+  if (!confirm("Na pewno wyczyścić wszystkie zapisy?")) return;
+  state.signups = [];
+  save();
+  renderSlots();
+  renderAdmin();
+  botSpeak("Panel admina: wszystkie zapisy zostały usunięte.");
+});
+
+renderSlots();
+renderAdmin();
+botSpeak("Cześć! Napisz „wolne terminy” albo „chcę się zapisać”.");

--- a/app.js
+++ b/app.js
@@ -1,12 +1,12 @@
 const defaultSlots = [
-  { id: "2026-06-12 17:00", title: "12.06.2026, 17:00 • Makrama", capacity: 5 },
-  { id: "2026-06-19 18:00", title: "19.06.2026, 18:00 • Biżuteria handmade", capacity: 6 },
-  { id: "2026-06-26 17:30", title: "26.06.2026, 17:30 • Świece sojowe", capacity: 4 }
+  { id: "2026-06-12 17:00", title: "12.06.2026, 17:00 • Układanie bukietów florystycznych", capacity: 5 },
+  { id: "2026-06-19 18:00", title: "19.06.2026, 18:00 • Kurs stroików sezonowych", capacity: 6 },
+  { id: "2026-06-26 17:30", title: "26.06.2026, 17:30 • Warsztaty pisanek dekoracyjnych", capacity: 4 }
 ];
 
 const state = {
-  slots: JSON.parse(localStorage.getItem("handmade_slots") || "null") || defaultSlots,
-  signups: JSON.parse(localStorage.getItem("handmade_signups") || "[]")
+  slots: JSON.parse(localStorage.getItem("florystyka_slots") || "null") || defaultSlots,
+  signups: JSON.parse(localStorage.getItem("florystyka_signups") || "[]")
 };
 
 const slotsList = document.getElementById("slotsList");
@@ -21,8 +21,8 @@ const chatForm = document.getElementById("chatForm");
 const chatInput = document.getElementById("chatInput");
 
 function save() {
-  localStorage.setItem("handmade_slots", JSON.stringify(state.slots));
-  localStorage.setItem("handmade_signups", JSON.stringify(state.signups));
+  localStorage.setItem("florystyka_slots", JSON.stringify(state.slots));
+  localStorage.setItem("florystyka_signups", JSON.stringify(state.signups));
 }
 
 function freePlaces(slotId) {
@@ -112,22 +112,23 @@ function userSpeak(text) {
 function botHandle(input) {
   const text = input.toLowerCase();
 
-  if (text.includes("wolne") || text.includes("termin")) {
+  if (text.includes("wolne") || text.includes("termin") || text.includes("kurs")) {
     const summary = state.slots
       .map(s => `${s.title} (${freePlaces(s.id)} wolnych)`)
       .join("; ");
-    return `Aktualne miejsca: ${summary}`;
+    return `Aktualne miejsca na kursy: ${summary}`;
   }
 
   if (text.includes("zapis") || text.includes("chcę")) {
-    const candidate = state.slots.find(s => text.includes(s.id.slice(5, 10).replace("-", ".")) || text.includes(s.title.slice(0, 5)));
+    const candidate = state.slots.find(s => text.includes("kwiat") && s.title.toLowerCase().includes("bukiet")
+      || text.includes("stroik") && s.title.toLowerCase().includes("stroik")
+      || text.includes("pisank") && s.title.toLowerCase().includes("pisanek"));
     const slot = candidate || state.slots.find(s => freePlaces(s.id) > 0);
 
     if (!slot) return "Niestety wszystkie terminy są pełne.";
 
-    const fakeName = "Uczestnik z czatu";
     const result = addSignup({
-      name: fakeName,
+      name: "Uczestnik z czatu",
       email: "chat@lokalnie.pl",
       phone: "000-000-000",
       slotId: slot.id,
@@ -140,7 +141,7 @@ function botHandle(input) {
       : result.message;
   }
 
-  return "Mogę: 1) pokazać wolne terminy, 2) zrobić szybki zapis na najbliższe szkolenie.";
+  return "Mogę: 1) pokazać wolne terminy kursów, 2) zrobić szybki zapis na kurs florystyczny, pisanki lub stroiki.";
 }
 
 chatForm.addEventListener("submit", e => {
@@ -165,4 +166,4 @@ clearDataButton.addEventListener("click", () => {
 
 renderSlots();
 renderAdmin();
-botSpeak("Cześć! Napisz „wolne terminy” albo „chcę się zapisać”.");
+botSpeak("Cześć! Napisz „wolne terminy”, „kurs kwiatów”, „kurs stroików” albo „chcę się zapisać”.");

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Pracownia Handmade • Warsztaty i Zapisy</title>
+  <title>Pracownia Florystyczna • Kursy i Zapisy</title>
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
@@ -13,10 +13,11 @@
       <a href="#rejestracja" class="cta">Zapisz się</a>
     </nav>
     <section class="hero-content">
-      <p class="tag">Rękodzieło z sercem</p>
-      <h2>Twórz piękne rzeczy podczas kameralnych szkoleń handmade</h2>
+      <p class="tag">Kwiaty i dekoracje z sercem</p>
+      <h2>Kursy florystyczne, pisanki i stroiki — twórz piękne ozdoby krok po kroku</h2>
       <p>
-        Organizujemy warsztaty dla początkujących i zaawansowanych. Wybierz termin,
+        Prowadzimy kameralne zajęcia: układanie kwiatów, florystyka użytkowa,
+        tworzenie pisanek i stroików sezonowych. Wybierz termin,
         zapisz się przez formularz albo porozmawiaj z botem, który pomoże Ci dobrać wolne miejsce.
       </p>
       <a href="#chat" class="cta secondary">Zapytaj bota</a>
@@ -25,7 +26,7 @@
 
   <main>
     <section id="terminy" class="card">
-      <h3>Dostępne terminy szkoleń</h3>
+      <h3>Dostępne terminy kursów</h3>
       <ul id="slotsList"></ul>
     </section>
 
@@ -44,7 +45,7 @@
         <label>Wybierz termin
           <select name="slot" id="slotSelect" required></select>
         </label>
-        <button type="submit">Zapisz na warsztat</button>
+        <button type="submit">Zapisz na kurs</button>
       </form>
       <p id="signupMessage" class="message"></p>
     </section>
@@ -53,7 +54,7 @@
       <h3>Bot zapisów</h3>
       <div id="chatWindow" class="chat-window"></div>
       <form id="chatForm" class="chat-form">
-        <input id="chatInput" type="text" placeholder="Np. Chcę się zapisać na 12.06" required />
+        <input id="chatInput" type="text" placeholder="Np. Chcę się zapisać na kurs stroików" required />
         <button type="submit">Wyślij</button>
       </form>
     </section>
@@ -77,7 +78,7 @@
   </main>
 
   <footer>
-    <p>© 2026 Pracownia Włóczki i Szperki • handmade • warsztaty • społeczność</p>
+    <p>© 2026 Pracownia Włóczki i Szperki • florystyka • pisanki • stroiki</p>
   </footer>
 
   <script src="app.js"></script>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,85 @@
+<!doctype html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Pracownia Handmade • Warsztaty i Zapisy</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="hero">
+    <nav>
+      <h1>Pracownia „Włóczki i Szperki”</h1>
+      <a href="#rejestracja" class="cta">Zapisz się</a>
+    </nav>
+    <section class="hero-content">
+      <p class="tag">Rękodzieło z sercem</p>
+      <h2>Twórz piękne rzeczy podczas kameralnych szkoleń handmade</h2>
+      <p>
+        Organizujemy warsztaty dla początkujących i zaawansowanych. Wybierz termin,
+        zapisz się przez formularz albo porozmawiaj z botem, który pomoże Ci dobrać wolne miejsce.
+      </p>
+      <a href="#chat" class="cta secondary">Zapytaj bota</a>
+    </section>
+  </header>
+
+  <main>
+    <section id="terminy" class="card">
+      <h3>Dostępne terminy szkoleń</h3>
+      <ul id="slotsList"></ul>
+    </section>
+
+    <section id="rejestracja" class="card">
+      <h3>Szybki zapis</h3>
+      <form id="signupForm">
+        <label>Imię i nazwisko
+          <input type="text" name="name" required />
+        </label>
+        <label>Email
+          <input type="email" name="email" required />
+        </label>
+        <label>Telefon
+          <input type="tel" name="phone" required />
+        </label>
+        <label>Wybierz termin
+          <select name="slot" id="slotSelect" required></select>
+        </label>
+        <button type="submit">Zapisz na warsztat</button>
+      </form>
+      <p id="signupMessage" class="message"></p>
+    </section>
+
+    <section id="chat" class="card">
+      <h3>Bot zapisów</h3>
+      <div id="chatWindow" class="chat-window"></div>
+      <form id="chatForm" class="chat-form">
+        <input id="chatInput" type="text" placeholder="Np. Chcę się zapisać na 12.06" required />
+        <button type="submit">Wyślij</button>
+      </form>
+    </section>
+
+    <section id="admin" class="card">
+      <h3>Panel administratora</h3>
+      <p>Podgląd zgłoszeń i wolnych miejsc (lokalnie w przeglądarce).</p>
+      <table>
+        <thead>
+          <tr>
+            <th>Uczestnik</th>
+            <th>Kontakt</th>
+            <th>Termin</th>
+            <th>Źródło</th>
+          </tr>
+        </thead>
+        <tbody id="adminRows"></tbody>
+      </table>
+      <button id="clearData" class="danger">Wyczyść zapisy</button>
+    </section>
+  </main>
+
+  <footer>
+    <p>© 2026 Pracownia Włóczki i Szperki • handmade • warsztaty • społeczność</p>
+  </footer>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,111 @@
+:root {
+  --bg: #fff9f5;
+  --surface: #ffffff;
+  --brand: #b95c6b;
+  --brand-dark: #934553;
+  --text: #2e2630;
+  --muted: #7e6f79;
+  --line: #f1dce2;
+  --ok: #2b7a4b;
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: "Segoe UI", Tahoma, sans-serif;
+  background: radial-gradient(circle at top right, #ffe8ef 0%, var(--bg) 50%);
+  color: var(--text);
+}
+
+.hero { padding: 2rem 1rem 4rem; }
+nav {
+  max-width: 1100px;
+  margin: 0 auto 2rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+h1 { margin: 0; font-size: 1.3rem; }
+.hero-content {
+  max-width: 1100px;
+  margin: 0 auto;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 1rem;
+  padding: 2rem;
+  box-shadow: 0 20px 40px rgba(185, 92, 107, 0.12);
+}
+.tag { color: var(--brand); font-weight: 700; }
+
+main {
+  max-width: 1100px;
+  margin: -2rem auto 2rem;
+  padding: 0 1rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1rem;
+}
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 1rem;
+  padding: 1.2rem;
+}
+
+.cta, button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.7rem 1rem;
+  background: var(--brand);
+  color: #fff;
+  text-decoration: none;
+  cursor: pointer;
+  font-weight: 600;
+}
+.cta.secondary { background: var(--brand-dark); }
+button.danger { background: #8f2838; margin-top: 1rem; }
+
+form { display: grid; gap: 0.8rem; }
+label { display: grid; gap: 0.25rem; font-size: 0.9rem; }
+input, select {
+  border: 1px solid #dcc2cb;
+  border-radius: 0.6rem;
+  padding: 0.55rem;
+  font: inherit;
+}
+
+#slotsList { padding-left: 1rem; }
+#slotsList li { margin-bottom: 0.35rem; color: var(--muted); }
+.message { color: var(--ok); min-height: 1.2rem; }
+
+.chat-window {
+  min-height: 180px;
+  max-height: 260px;
+  overflow-y: auto;
+  border: 1px solid var(--line);
+  border-radius: 0.8rem;
+  padding: 0.7rem;
+  background: #fffdff;
+}
+.msg { margin: 0.5rem 0; }
+.msg.bot { color: #5b3f58; }
+.msg.user { text-align: right; color: #234; }
+
+.chat-form {
+  margin-top: 0.7rem;
+  display: flex;
+  gap: 0.5rem;
+}
+.chat-form input { flex: 1; }
+
+table { width: 100%; border-collapse: collapse; font-size: 0.9rem; }
+th, td { border-bottom: 1px solid var(--line); padding: 0.45rem; text-align: left; }
+
+footer {
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.9rem;
+  padding: 1rem;
+}


### PR DESCRIPTION
### Motivation
- Provide a polished single-page landing site for a handmade workshop with booking capabilities and a simple conversational assistant.
- Allow visitors to view available workshops and sign up, and allow organizers to review and clear signups locally.
- Ship a lightweight, client-side prototype that works without a server so it can be tested and deployed quickly.

### Description
- Added page structure and sections in `index.html` (hero, available slots, registration form, chat bot, admin table). 
- Implemented styles in `styles.css` for a warm, responsive card-based layout and UI elements. 
- Implemented application logic in `app.js`, including default `slots`, `localStorage`-backed `state`, rendering (`renderSlots`, `renderAdmin`), signup flow (`addSignup`) that prevents overbooking and disables full options, chat-bot handling (`botHandle`) for listing slots and making provisional signups, and admin actions (rendering signups and `clearData`).
- Data persistence is local for this prototype via `localStorage` and the chat bot is rule-based and intentionally simple for demo use.

### Testing
- Ran `git status --short` to inspect repository state, which succeeded. 
- Committed new files with `git add index.html styles.css app.js && git commit -m "Create handmade workshop site with signup bot and admin panel"`, which succeeded and added 3 files. 
- Re-ran `git status --short` to confirm no outstanding changes, which succeeded. 
- No unit tests or CI were run for this prototype.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f82ea7d08832fbe5ecfd4543ddad3)